### PR TITLE
Don't add versions like '0.0.0' to previous artifacts

### DIFF
--- a/src/main/scala/sbtcompatibility/version/Version.scala
+++ b/src/main/scala/sbtcompatibility/version/Version.scala
@@ -28,6 +28,8 @@ object Version {
       val stripped = version.takeWhile(_ != '+')
       if (tagPattern.findAllMatchIn(stripped).isEmpty)
         Some(stripped)
+          // assume versions like '0.0.0' aren't published
+          .filter(_.exists(c => c.isDigit && c != '0'))
       else
         previousStableVersion(stripped)
     } else

--- a/src/test/scala/sbtcompatibility/VersionsTests.scala
+++ b/src/test/scala/sbtcompatibility/VersionsTests.scala
@@ -24,6 +24,7 @@ object VersionsTests extends TestSuite {
       * -  check("1.1-RC2", "1.0")
       * - checkEmpty("1.0-RC2")
       * - checkEmpty("1.0-RC2+43")
+      * - checkEmpty("0.0.0+3-70919203-SNAPSHOT")
     }
 
     "compatible" - {


### PR DESCRIPTION
This could happen with sbt-dynver generated versions like '0.0.0+3-70919203-SNAPSHOT'.