### PR TITLE
Clean-up implementation and improve documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ inThisBuild(List(
 ))
 
 lazy val root = (project in file("."))
-  .aggregate(`sbt-version-policy`, `sbt-version-policy-dummy`)
+  .aggregate(`sbt-version-policy`)
   .settings(
     name := "sbt-version-policy root",
     publish / skip := true,
@@ -37,6 +37,3 @@ lazy val `sbt-version-policy` = project
     ),
     testFrameworks += new TestFramework("verify.runner.Framework"),
   )
-
-lazy val `sbt-version-policy-dummy` = project
-  .in(file("sbt-version-policy/target/dummy"))

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyInternalKeys.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyInternalKeys.scala
@@ -15,7 +15,6 @@ trait SbtVersionPolicyInternalKeys {
   final val versionPolicyIgnoreSbtDefaultReconciliations = settingKey[Boolean]("")
   final val versionPolicyUseCsrConfigReconciliations     = settingKey[Boolean]("")
 
-  final val versionPolicyAutoPreviousArtifacts     = taskKey[Seq[ModuleID]]("")
   final val versionPolicyPreviousArtifactsFromMima = taskKey[Seq[ModuleID]]("")
 
   final val versionPolicyDetailedReconciliations = taskKey[Seq[(ModuleMatchers, VersionCompatibility)]]("")

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
@@ -99,7 +99,7 @@ object SbtVersionPolicyMima extends AutoPlugin {
           else Nil
         case None =>
           if (firstOpt.nonEmpty)
-            sys.error(s"""Cannot compute previous version from $ver. To fix that error, set previousVersions or unset versionPolicyFirstVersion.""")
+            sys.error(s"""Cannot compute previous version from $ver. To fix that error, set versionPolicyPreviousVersions or unset versionPolicyFirstVersion.""")
           Nil
       }
     },

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -102,12 +102,6 @@ object SbtVersionPolicySettings {
         .sortBy(_._1)
         .map(_._2)
     },
-    versionPolicyAutoPreviousArtifacts := {
-      val projId = projectID.value
-      versionPolicyPreviousVersions.value.map { version =>
-        projId.withRevision(version)
-      }
-    },
 
     versionPolicyPreviousArtifacts := versionPolicyPreviousArtifactsFromMima.value
   )
@@ -246,8 +240,8 @@ object SbtVersionPolicySettings {
       }
     },
     versionPolicyCheck := {
-      versionPolicyMimaCheck.value
-      versionPolicyReportDependencyIssues.value
+      val ignored1 = versionPolicyMimaCheck.value
+      val ignored2 = versionPolicyReportDependencyIssues.value
     },
     versionPolicyForwardCompatibilityCheck := {
       import MimaPlugin.autoImport._
@@ -286,8 +280,8 @@ object SbtVersionPolicySettings {
         case BinaryCompatible => MimaPlugin.autoImport.mimaReportBinaryIssues
         case BinaryAndSourceCompatible =>
           Def.task {
-            versionPolicyForwardCompatibilityCheck.value
-            MimaPlugin.autoImport.mimaReportBinaryIssues.value
+            val ignored1 = versionPolicyForwardCompatibilityCheck.value
+            val ignored2 = MimaPlugin.autoImport.mimaReportBinaryIssues.value
           }
         case None => Def.task { () } // skip mima if no compatibility is intented
       }


### PR DESCRIPTION
- Remove project `sbt-version-policy-dummy`
- Remove unused internal key `versionPolicyAutoPreviousArtifacts`
- Fix warnings caused by “expressions in statement position”
- Extend documentation