### PR TITLE
Reduce memory consumption

### DIFF
--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -321,7 +321,7 @@ object SbtVersionPolicySettings {
     versionPolicyIgnoredInternalDependencyVersions.value match {
       case Some(versionRegex) =>
         allProjectRefs.foldLeft(Def.setting(Set.empty[(String, String)])) { case (previousModules, (projectRef, _)) =>
-          Def.setting {
+          Def.settingDyn {
             val projectOrganization       = (projectRef / organization).value
             val projectName               = (projectRef / moduleName).value
             val projectVersion            = (projectRef / version).value
@@ -333,10 +333,10 @@ object SbtVersionPolicySettings {
                 CrossVersion(projectCrossVersion, projectScalaVersion, projectScalaBinaryVersion)
                   .fold(projectName)(_(projectName))
               val module = projectOrganization -> nameWithBinarySuffix
-              previousModules.value + module
+              Def.setting(previousModules.value + module)
             } else {
               // Don’t include the module if its version does not match the regex
-              previousModules.value
+              Def.setting(previousModules.value)
             }
           }
         }


### PR DESCRIPTION
Creating chains of settings was consuming an exponential amount of memory. This did not scale when used with builds with dozens of modules.

By using dynamic settings, the chain of dependencies is not kept, resulting in less memory consumption.