### PR TITLE
Facilitate using the plugin for custom reports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ inThisBuild(List(
       url("https://github.com/alexarchambault")
     )
   ),
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   libraryDependencySchemes += "com.typesafe" %% "mima-core" % "semver-spec"
 ))
 

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyKeys.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyKeys.scala
@@ -3,6 +3,7 @@ package sbtversionpolicy
 import coursier.version.VersionCompatibility
 import sbt._
 import sbt.librarymanagement.DependencyBuilders.OrganizationArtifactName
+import sbtversionpolicy.internal.DependencyCheck
 
 import scala.util.matching.Regex
 
@@ -13,6 +14,7 @@ trait SbtVersionPolicyKeys {
   final val versionPolicyCheck                  = taskKey[Unit]("Runs both versionPolicyReportDependencyIssues and versionPolicyMimaCheck")
   final val versionPolicyMimaCheck              = taskKey[Unit]("Runs Mima to check backward or forward compatibility depending on the intended change defined via versionPolicyIntention.")
   final val versionPolicyForwardCompatibilityCheck = taskKey[Unit]("Report forward binary compatible issues from Mima.")
+  final val versionPolicyDependencyIssuesReporter = taskKey[DependencyCheck.Reporter]("Helper to find issues in the library dependencies.")
   final val versionPolicyFindDependencyIssues   = taskKey[Seq[(ModuleID, DependencyCheckReport)]]("Compatibility issues in the library dependencies.")
   final val versionCheck                        = taskKey[Unit]("Checks that the version is consistent with the intended compatibility level defined via versionPolicyIntention")
 

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
@@ -27,7 +27,7 @@ object SbtVersionPolicyMima extends AutoPlugin {
   private def moduleName(m: ModuleID, sv: String, sbv: String): String =
     moduleName(m.crossVersion, sv, sbv, m.name)
 
-  private lazy val previousVersionsFromRepo = Def.setting {
+  lazy val previousVersionsFromRepo = Def.setting {
 
     val projId = Keys.projectID.value
     val sv = Keys.scalaVersion.value

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
@@ -103,18 +103,20 @@ object SbtVersionPolicyMima extends AutoPlugin {
     },
 
     mimaPreviousArtifacts := {
-      val projId = Keys.projectID.value.withExplicitArtifacts(Vector.empty)
-      val previousVersions0 = versionPolicyPreviousVersions.value
-
-      previousVersions0.toSet.map { version =>
-        projId
-          .withExtraAttributes {
-            projId.extraAttributes
-              .filter(!_._1.stripPrefix("e:").startsWith("info."))
-          }
-          .withRevision(version)
-      }
+      computePreviousArtifacts(Keys.projectID.value, versionPolicyPreviousVersions.value)
     }
   )
 
+  def computePreviousArtifacts(projectID: ModuleID, previousVersions: Seq[String]) = {
+    val projId = projectID.withExplicitArtifacts(Vector.empty)
+
+    previousVersions.toSet.map { version =>
+      projId
+        .withExtraAttributes {
+          projId.extraAttributes
+            .filter(!_._1.stripPrefix("e:").startsWith("info."))
+        }
+        .withRevision(version)
+    }
+  }
 }

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -93,19 +93,22 @@ object SbtVersionPolicySettings {
 
   def previousArtifactsSettings = Def.settings(
     versionPolicyPreviousArtifactsFromMima := {
-      import Ordering.Implicits._
-      MimaPlugin.autoImport.mimaPreviousArtifacts.value
-        .toVector
-        .map { mod =>
-          val splitVersion = mod.revision.split('.').map(s => Try(s.toInt).getOrElse(-1)).toSeq
-          (splitVersion, mod)
-        }
-        .sortBy(_._1)
-        .map(_._2)
+      fromMimaArtifacts(MimaPlugin.autoImport.mimaPreviousArtifacts.value)
     },
-
     versionPolicyPreviousArtifacts := versionPolicyPreviousArtifactsFromMima.value
   )
+
+  def fromMimaArtifacts(artifacts: Set[sbt.ModuleID]) = {
+    import Ordering.Implicits.*
+    artifacts
+      .toVector
+      .map { mod =>
+        val splitVersion = mod.revision.split('.').map(s => Try(s.toInt).getOrElse(-1)).toSeq
+        (splitVersion, mod)
+      }
+      .sortBy(_._1)
+      .map(_._2)
+  }
 
   def findIssuesSettings = Def.settings(
     versionPolicyDependencyIssuesReporter := {

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -108,7 +108,7 @@ object SbtVersionPolicySettings {
   )
 
   def findIssuesSettings = Def.settings(
-    versionPolicyFindDependencyIssues := {
+    versionPolicyDependencyIssuesReporter := {
       val log = streams.value.log
       val sv = scalaVersion.value
       val sbv = scalaBinaryVersion.value
@@ -117,9 +117,6 @@ object SbtVersionPolicySettings {
         sys.error("Compile configuration not found in update report")
       }
 
-      val compatibilityIntention =
-        versionPolicyIntention.?.value
-          .getOrElse(throw new MessageOnlyException("Please set the key versionPolicyIntention to declare the compatibility you want to check"))
       val depRes = versionPolicyDependencyResolution.value
       val scalaModuleInf = versionPolicyScalaModuleInfo.value
       val updateConfig = versionPolicyUpdateConfiguration.value
@@ -140,32 +137,24 @@ object SbtVersionPolicySettings {
           log
         )
 
+      new DependencyCheck.Reporter(
+        excludedModules,
+        currentDependencies,
+        reconciliations,
+        VersionCompatibility.Strict,
+        sv,
+        sbv,
+        depRes,
+        scalaModuleInf,
+        updateConfig,
+        warningConfig,
+        log
+      )
+    },
+    versionPolicyFindDependencyIssues := {
+      val compatibilityIntention = requirePolicyIntentionOrThrow(versionPolicyIntention.?.value)
       val previousModuleIds = versionPolicyPreviousArtifacts.value
-
-      // Skip dependency check if no compatibility is intended
-      if (compatibilityIntention == Compatibility.None) Nil else {
-
-        previousModuleIds.map { previousModuleId =>
-
-          val report0 = DependencyCheck.report(
-            compatibilityIntention,
-            excludedModules,
-            currentDependencies,
-            previousModuleId,
-            reconciliations,
-            VersionCompatibility.Strict,
-            sv,
-            sbv,
-            depRes,
-            scalaModuleInf,
-            updateConfig,
-            warningConfig,
-            log
-          )
-
-          (previousModuleId, report0)
-        }
-      }
+      versionPolicyDependencyIssuesReporter.value.apply(compatibilityIntention, previousModuleIds)
     },
     versionPolicyReportDependencyIssues := {
       val log = streams.value.log
@@ -173,9 +162,7 @@ object SbtVersionPolicySettings {
       val sbv = scalaBinaryVersion.value
       val direction = versionPolicyCheckDirection.value
       val reports = versionPolicyFindDependencyIssues.value
-      val intention =
-        versionPolicyIntention.?.value
-          .getOrElse(throw new MessageOnlyException("Please set the key versionPolicyIntention to declare the compatibility you want to check"))
+      val intention = requirePolicyIntentionOrThrow(versionPolicyIntention.?.value)
       val currentModule = projectID.value
       val formattedPreviousVersions = formatVersions(versionPolicyPreviousVersions.value)
 
@@ -263,9 +250,7 @@ object SbtVersionPolicySettings {
     },
     versionPolicyMimaCheck := Def.taskDyn {
       import Compatibility._
-      val compatibility =
-        versionPolicyIntention.?.value
-          .getOrElse(throw new MessageOnlyException("Please set the key versionPolicyIntention to declare the compatibility you want to check"))
+      val compatibility = requirePolicyIntentionOrThrow(versionPolicyIntention.?.value)
       val log = streams.value.log
       val currentModule = projectID.value
       val formattedPreviousVersions = formatVersions(versionPolicyPreviousVersions.value)
@@ -301,6 +286,14 @@ object SbtVersionPolicySettings {
       }
     }.value
   )
+
+  private def requirePolicyIntentionOrThrow(maybeCompatibility: Option[Compatibility]) =
+    maybeCompatibility
+      .getOrElse(
+        throw new MessageOnlyException(
+          "Please set the key versionPolicyIntention to declare the compatibility you want to check"
+        )
+      )
 
   def skipSettings = Seq(
     versionCheck / skip := (publish / skip).value,

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/internal/DependencyCheck.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/internal/DependencyCheck.scala
@@ -81,7 +81,7 @@ object DependencyCheck {
     reconciliations: Seq[(ModuleMatchers, VersionCompatibility)],
     defaultReconciliation: VersionCompatibility,
     sv: String,
-    sbv: String,
+    scalaBinaryVersion: String,
     depRes: DependencyResolution,
     scalaModuleInf: Option[ScalaModuleInfo],
     updateConfig: UpdateConfiguration,

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/internal/DependencyCheck.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/internal/DependencyCheck.scala
@@ -75,6 +75,47 @@ object DependencyCheck {
       log
     )
 
+  class Reporter(
+    excludedModules: Set[(String, String)],
+    currentDependencies: Map[(String, String), String],
+    reconciliations: Seq[(ModuleMatchers, VersionCompatibility)],
+    defaultReconciliation: VersionCompatibility,
+    sv: String,
+    sbv: String,
+    depRes: DependencyResolution,
+    scalaModuleInf: Option[ScalaModuleInfo],
+    updateConfig: UpdateConfiguration,
+    warningConfig: UnresolvedWarningConfiguration,
+    log: Logger
+  ) {
+    def apply(compatibilityIntention: Compatibility, previousModuleIds: Seq[ModuleID]) =
+    // Skip dependency check if no compatibility is intended
+      if (compatibilityIntention == Compatibility.None) Nil else {
+
+        previousModuleIds.map { previousModuleId =>
+
+          val report0 = report(
+            compatibilityIntention,
+            excludedModules,
+            currentDependencies,
+            previousModuleId,
+            reconciliations,
+            defaultReconciliation,
+            sv,
+            sbv,
+            depRes,
+            scalaModuleInf,
+            updateConfig,
+            warningConfig,
+            log
+          )
+
+          (previousModuleId, report0)
+        }
+      }
+
+  }
+
   private[sbtversionpolicy] def report(
     compatibilityIntention: Compatibility,
     excludedModules: Set[(String, String)],


### PR DESCRIPTION
See #119 

I think to avoid needing a special SBT configuration I would need to make similar changes in sbt-mima :(

But so far this PR enables the following diff to the Slick PR (again, see #119):

```diff
diff --git a/project/Versioning.scala b/project/Versioning.scala
index 457183cc..1f7ae653 100644
--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -1,16 +1,15 @@
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaFindBinaryIssues
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import coursier.version.Version
-import sbt.librarymanagement.CrossVersion
-import sbt.{AutoPlugin, Compile, Def, Defaults, Keys, config, inConfig, settingKey, taskKey}
+import sbt.{AutoPlugin, Compile, Defaults, Keys, config, inConfig, settingKey, taskKey}
 import sbtdynver.DynVerPlugin.autoImport.{dynver, dynverCurrentDate, dynverGitDescribeOutput}
 import sbtdynver.{DynVer, GitDescribeOutput}
 import sbtversionpolicy.SbtVersionPolicyMima.autoImport.versionPolicyPreviousVersions
-import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport._
-import sbtversionpolicy.{DependencyCheckReport, Direction, SbtVersionPolicyMima, SbtVersionPolicyPlugin}
+import sbtversionpolicy.SbtVersionPolicyMima.previousVersionsFromRepo
+import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport.{versionPolicyCheckDirection, versionPolicyDependencyIssuesReporter, versionPolicyIntention}
+import sbtversionpolicy._
 
 import java.util.Date
-import scala.jdk.CollectionConverters._
 
 
 object Versioning extends AutoPlugin {
@@ -49,31 +48,6 @@ object Versioning extends AutoPlugin {
   def versionFor(compat: Compatibility, date: Date = new Date): Option[String] =
     DynVer.getGitDescribeOutput(date).map(versionFor(compat, _))
 
-  // Code copied from sbt-version-policy
-  private lazy val previousVersionsFromRepo = Def.setting {
-    val projId = Keys.projectID.value
-    val sv = Keys.scalaVersion.value
-    val sbv = Keys.scalaBinaryVersion.value
-    val name = CrossVersion(projId.crossVersion, sv, sbv).fold(projId.name)(_ (projId.name))
-
-    val ivyProps = sbtversionpolicy.internal.Resolvers.defaultIvyProperties(Keys.ivyPaths.value.ivyHome)
-    val repos = Keys.resolvers.value.flatMap { res =>
-      val repoOpt = sbtversionpolicy.internal.Resolvers.repository(res, ivyProps, s => System.err.println(s))
-      if (repoOpt.isEmpty)
-        System.err.println(s"Warning: ignoring repository ${res.name} to get previous version")
-      repoOpt.toSeq
-    }
-    // Can't reference Keys.fullResolvers, which is a task.
-    // So we're using the usual default repositories from coursier here…
-    val fullRepos = coursierapi.Repository.defaults().asScala ++ repos
-    val res = coursierapi.Versions.create()
-      .withRepositories(fullRepos: _*)
-      .withModule(coursierapi.Module.of(projId.organization, name))
-      .versions()
-    res.getMergedListings.getAvailable.asScala
-  }
-
-
   override def trigger = allRequirements
 
   val previousRelease = settingKey[Option[String]]("Determine the artifact of the previous release")
@@ -136,7 +110,18 @@ object Versioning extends AutoPlugin {
             versionPolicyCheckDirection := Direction.both,
             versionPolicyIntention := BumpMinor,
             reportCompat := {
-              val dependencyIssues = versionPolicyFindDependencyIssues.value.toMap
+              val dependencyIssues =
+                versionPolicyDependencyIssuesReporter.value
+                  .apply(
+                    BumpMinor,
+                    SbtVersionPolicySettings.fromMimaArtifacts(
+                      SbtVersionPolicyMima.computePreviousArtifacts(
+                        Keys.projectID.value,
+                        previousRelease.value.toList
+                      )
+                    )
+                  )
+                  .toMap
               val mimaIssues = mimaFindBinaryIssues.value.map { case (module, problems) =>
                 module.withName(module.name.stripSuffix("_" + Keys.scalaBinaryVersion.value)) -> problems
               }
```
