### PR TITLE
bind versionPolicyModuleVersionExtractor in build settings

### DIFF
--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -31,7 +31,6 @@ object SbtVersionPolicySettings {
     versionPolicyDependencyResolution := CoursierDependencyResolution(versionPolicyCsrConfiguration.value),
     versionPolicyUpdateConfiguration := updateConfiguration.value,
     versionPolicyUnresolvedWarningConfiguration := (update / unresolvedWarningConfiguration).value,
-    versionPolicyModuleVersionExtractor := PartialFunction.empty,
     versionPolicyScalaModuleInfo := scalaModuleInfo.value
   )
 
@@ -51,7 +50,8 @@ object SbtVersionPolicySettings {
     versionPolicyDefaultDependencySchemes := defaultSchemes,
     versionPolicyIgnored := Seq.empty,
     versionPolicyDefaultScheme := None,
-    versionPolicyIgnoredInternalDependencyVersions := None
+    versionPolicyIgnoredInternalDependencyVersions := None,
+    versionPolicyModuleVersionExtractor := PartialFunction.empty
   )
 
   def reconciliationSettings = Def.settings(


### PR DESCRIPTION
I didn't realize that `updateSettings` were set as project settings. Let's set the default value for `versionPolicyModuleVersionExtractor` in build settings. That makes it easier for clients to override for the entire build.