### PR TITLE
Improve the error reporting

### DIFF
--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/Compatibility.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/Compatibility.scala
@@ -64,8 +64,14 @@ object Compatibility {
    * Validates that the given new `version` matches the claimed `compatibility` level.
    * @return Some validation error, or None if the version is valid.
    */
-  def isValidVersion(compatibility: Compatibility, version: String): Boolean = {
-    val versionNumber = VersionNumber(version)
+  def isValidVersion(compatibility: Compatibility, version: String): Boolean =
+    isValidVersion(compatibility, VersionNumber(version))
+
+  /**
+   * Validates that the given new `version` matches the claimed `compatibility` level.
+   * @return Some validation error, or None if the version is valid.
+   */
+  private[sbtversionpolicy] def isValidVersion(compatibility: Compatibility, versionNumber: VersionNumber): Boolean = {
     val major = versionNumber._1
     val minor = versionNumber._2
     val patch = versionNumber._3


### PR DESCRIPTION
versionCheck checks that the declared version number (e.g. 1.2.3) conforms to the declared compatibility guarantees (e.g. Compatibility.BinaryAndSourceCompatible).

Previously, when versionCheck failed, it only reported that the declared version was invalid. Now, it shows both the declared version and the compatibility intention. It also mentions the possibility to restrict the compatibility guarantees to fix the failure.

Fixes #126 