### PR TITLE
fix #155 by extracting version without suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+# SBT stuff
 target/
+
+# Bloop/Metals/VSCode stuff
+.bloop
+.bsp
+.metals
+.vscode
+metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.tools.mima.core._
 
 inThisBuild(List(
   organization := "ch.epfl.scala",
@@ -37,5 +38,9 @@ lazy val `sbt-version-policy` = project
       "io.get-coursier" %% "versions" % "0.3.1",
       "com.eed3si9n.verify" %% "verify" % "2.0.1" % Test,
     ),
-    testFrameworks += new TestFramework("verify.runner.Framework")
+    testFrameworks += new TestFramework("verify.runner.Framework"),
+    mimaBinaryIssueFilters ++= Seq(
+      // this class is `private` and it's only used from `extractSemVerNumbers` method, which is private
+      ProblemFilters.exclude[MissingClassProblem]("sbtversionpolicy.DependencyCheckReport$SemVerVersion*")
+    ),
   )

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/DependencyCheckReport.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/DependencyCheckReport.scala
@@ -167,10 +167,12 @@ object DependencyCheckReport {
 
   private def extractSemVerNumbers(versionString: String): Option[(Int, Int, Int)] = {
     val version = Version(versionString)
-    if (version.items.size == 3 && version.items.forall(_.isInstanceOf[Version.Number])) {
-      val Seq(major, minor, patch) = version.items.collect { case num: Version.Number => num.value }
-      Some((major, minor, patch))
-    } else None // Not a normalized version number (e.g., 1.0.0-RC1)
+    version.items match {
+      case Vector(major: Version.Number, minor: Version.Number, patch: Version.Number, _*) =>
+        Some((major.value, minor.value, patch.value))
+      case _ => 
+        None // Not a semantic version number (e.g., 1.0-RC1)
+    }
   }
 
 }

--- a/sbt-version-policy/src/test/scala/sbtversionpolicy/DependencyCheckReportTest.scala
+++ b/sbt-version-policy/src/test/scala/sbtversionpolicy/DependencyCheckReportTest.scala
@@ -32,8 +32,11 @@ object DependencyCheckReportTest extends BasicTestSuite {
       isCompatible("1.0.1",     "1.0.0")
       isBreaking  ("1.1.0",     "1.0.0")
       isBreaking  ("2.0.0",     "1.0.0")
-      isBreaking  ("1.0.0",     "1.0.0-RC1")
+      isBreaking  ("1.1.0",     "1.0.0-RC1")
+      isBreaking  ("2.0.0",     "1.0.0-RC1")
       isCompatible("1.0.0-RC1", "1.0.0-RC1")
+      isCompatible("1.0.0",     "1.0.0-RC1")
+      isCompatible("1.0.1",     "1.0.0-RC1")
     }
   }
 

--- a/sbt-version-policy/src/test/scala/sbtversionpolicy/DependencyCheckReportTest.scala
+++ b/sbt-version-policy/src/test/scala/sbtversionpolicy/DependencyCheckReportTest.scala
@@ -26,17 +26,15 @@ object DependencyCheckReportTest extends BasicTestSuite {
       isCompatible("1.2.3-RC1", "1.2.3-RC1")
     }
     withScheme(VersionCompatibility.EarlySemVer) { (isCompatible, isBreaking) =>
-      isBreaking  ("0.1.1",     "0.1.0")
-      isBreaking  ("0.2.0",     "0.1.0")
-      isBreaking  ("1.0.0",     "0.1.0")
-      isCompatible("1.0.1",     "1.0.0")
-      isBreaking  ("1.1.0",     "1.0.0")
-      isBreaking  ("2.0.0",     "1.0.0")
-      isBreaking  ("1.1.0",     "1.0.0-RC1")
-      isBreaking  ("2.0.0",     "1.0.0-RC1")
-      isCompatible("1.0.0-RC1", "1.0.0-RC1")
-      isCompatible("1.0.0",     "1.0.0-RC1")
-      isCompatible("1.0.1",     "1.0.0-RC1")
+      isBreaking  ("0.1.1",          "0.1.0")
+      isBreaking  ("0.2.0",          "0.1.0")
+      isBreaking  ("1.0.0",          "1.0.0-RC1")
+      isBreaking  ("1.0.1",          "1.0.0-RC1")
+      isBreaking  ("1.1.0",          "1.0.0-RC1")
+      isBreaking  ("2.0.0",          "1.0.0-RC1")
+      isCompatible("1.0.0-RC1",      "1.0.0-RC1")
+      isCompatible("1.0.1-RC1",      "1.0.0")
+      isCompatible("1.2.1-SNAPSHOT", "1.2.0")
     }
   }
 

--- a/sbt-version-policy/src/test/scala/sbtversionpolicy/DependencyCheckReportTest.scala
+++ b/sbt-version-policy/src/test/scala/sbtversionpolicy/DependencyCheckReportTest.scala
@@ -20,21 +20,29 @@ object DependencyCheckReportTest extends BasicTestSuite {
     withScheme(VersionCompatibility.PackVer) { (isCompatible, isBreaking) =>
       isBreaking  ("1.0.1",     "1.0.0")
       isBreaking  ("1.1.0",     "1.0.0")
-      isBreaking  ("2.0.0",     "1.0.0")
-      isCompatible("1.2.3",     "1.2.3")
-      isBreaking  ("1.2.3",     "1.2.3-RC1")
       isCompatible("1.2.3-RC1", "1.2.3-RC1")
+      isBreaking  ("1.2.3",     "1.2.3-RC1")
+      isCompatible("1.2.3",     "1.2.3")
+      isBreaking  ("2.0.0",     "1.0.0")
     }
     withScheme(VersionCompatibility.EarlySemVer) { (isCompatible, isBreaking) =>
       isBreaking  ("0.1.1",          "0.1.0")
       isBreaking  ("0.2.0",          "0.1.0")
-      isBreaking  ("1.0.0",          "1.0.0-RC1")
-      isBreaking  ("1.0.1",          "1.0.0-RC1")
-      isBreaking  ("1.1.0",          "1.0.0-RC1")
-      isBreaking  ("2.0.0",          "1.0.0-RC1")
       isCompatible("1.0.0-RC1",      "1.0.0-RC1")
+      isBreaking  ("1.0.0-RC2",      "1.0.0-RC1")
+      isBreaking  ("1.0.0",          "1.0.0-RC1")
       isCompatible("1.0.1-RC1",      "1.0.0")
+      isCompatible("1.0.1-RC2",      "1.0.1-RC1")    
+      isBreaking  ("1.0.1",          "1.0.0-RC1")
+      isCompatible("1.0.1",          "1.0.0")
+      isBreaking  ("1.1.0-RC1",      "1.0.0")
+      isBreaking  ("1.1.0-RC2",      "1.1.0-RC1")
+      isBreaking  ("1.1.0",          "1.0.0-RC1")
+      isBreaking  ("1.1.0",          "1.0.0")
       isCompatible("1.2.1-SNAPSHOT", "1.2.0")
+      isBreaking  ("2.0.0-RC1",      "1.0.0")
+      isBreaking  ("2.0.0",          "1.0.0-RC1")
+      isBreaking  ("2.0.0",          "1.0.0")
     }
   }
 


### PR DESCRIPTION
As proposed by @julienrf I've changed semver version extraction method to allow suffixes after first three numbers.

Test are updated accordingly.