### PR TITLE
Support establishing the actual level of compatibility

### DIFF
--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/CompatAssessment.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/CompatAssessment.scala
@@ -1,0 +1,19 @@
+package sbtversionpolicy
+
+import scala.math.Ordered._
+
+case class CompatAssessment(
+  attainedCompat: Compatibility,
+  failure: Option[Exception]
+) {
+  for {
+    f <- failure
+    failedCompat <- Compatibility.Levels.find(_ > attainedCompat)
+  } yield (failedCompat, f)
+}
+
+object CompatAssessment {
+  def apply(): CompatAssessment = {
+
+  }
+}

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyKeys.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyKeys.scala
@@ -7,7 +7,10 @@ import sbt.librarymanagement.DependencyBuilders.OrganizationArtifactName
 import scala.util.matching.Regex
 
 trait SbtVersionPolicyKeys {
-  final val versionPolicyIntention              = settingKey[Compatibility]("Compatibility intentions for the next release.")
+  final val versionPolicyIntention = settingKey[Compatibility]("Compatibility intentions for the next release.")
+  final val versionAssessMimaCompatibility = taskKey[Compatibility]("The compatability level of the code, based on the current state of the project.")
+  final val versionAssessDependencyCompatibility = taskKey[Compatibility]("The compatability level of the dependencies.")
+  final val versionAssessOverallCompatibility = taskKey[Compatibility]("The overall compatability level of the code & dependencies.")
   final val versionPolicyPreviousArtifacts      = taskKey[Seq[ModuleID]]("")
   final val versionPolicyReportDependencyIssues = taskKey[Unit]("Check for removed or updated dependencies in an incompatible way.")
   final val versionPolicyCheck                  = taskKey[Unit]("Runs both versionPolicyReportDependencyIssues and versionPolicyMimaCheck")

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -274,6 +274,20 @@ object SbtVersionPolicySettings {
       else Compatibility.None
     },
     versionAssessMimaCompatibility := {
+      /*
+      When being used for an Intention check, we want:
+      - the compatibility level attained
+      - the exception we got trying to attain that compatability level, if any (which would be from the level *above* the attained level...)
+
+      We want to say "project failed the binary compatability check with exception waawaah"
+
+      log.error(s"Module ${nameAndRevision(currentModule)} is not {intended} compatible with ${formattedPreviousVersions}. You have to relax your compatibility intention by changing the value of versionPolicyIntention.")
+      throw new MessageOnlyException(error.directCause.map(_.toString).getOrElse("versionPolicyForwardCompatibilityCheck failed"))
+
+      result.attainsCompatability = BinaryCompatible
+      result.failedToAttain = Some((SourceAndBinaryCompatible, exception))
+
+       */
       lastPopulatedValueOf(Compatibility.Levels.toList.flatMap { level =>
         level.checkThatMustPassForCompatabilityLevel.map(_.result.map(_.toEither.toOption.map(_ => level)))
       }).map(_.getOrElse(Compatibility.None)).value
@@ -286,6 +300,8 @@ object SbtVersionPolicySettings {
       val currentModule = nameAndRevision(projectID.value)
       val formattedPreviousVersions = formatVersions(versionPolicyPreviousVersions.value)
       val actualCompat = versionAssessMimaCompatibility.value
+      val actualCompat2 = versionAssessMimaCompatibility.value
+      val actualCompat3 = versionAssessMimaCompatibility.value
 
       println(s"actualCompat=$actualCompat")
 


### PR DESCRIPTION
I'd like to enable a workflow like this for developers working on libraries (for us at the Guardian, repos like [`content-api-scala-client`](https://github.com/guardian/content-api-scala-client), [`etag-caching`](https://github.com/guardian/etag-caching), etc):

1. **Keep devs aware of the compatibility of the PR they're working on** : When a PR is opened on a library repository, an automated workflow comments-on or labels the PR, making them aware that _"This PR breaks binary/source compatibility"_ - the information here would come from the `sbt-version-policy` plugin, but wouldn't require setting a `versionPolicyIntention` - it just establishes _what_ the level of compatibility the PR entails, so that the developer is aware. The assumption here is that whatever the developer is doing, they need to do it, and should just know the compatibility cost the PR is going to have (and possibly, though not necessarily, once informed they may be able to modify the PR to improve the compatibility).
1. **Required version increment automatically determined at release** : When merged, the developer can trigger an automated maven-publication workflow on the main branch. As part of that process, the level of compatibility with the previous release would again be established by `sbt-version-policy`, determining a resulting version number bump (major, minor, or patch), with the workflow determining what the resulting release version number should be, rather than the developer.

### Computing `Compatibility` without setting `versionPolicyIntention`

The main documented mode of operation with `sbt-version-policy` at the moment requires a target `sbtversionpolicy.Compatibility` to be selected by the developer with `versionPolicyIntention`, and then `sbt-version-policy` informs the developer whether or not they are hitting that target.

To enable the workflow described in this PR, we need a way to compute that `sbtversionpolicy.Compatibility` without actually setting a `versionPolicyIntention`, as mentioned in https://github.com/scalacenter/sbt-version-policy/issues/109

So far as I can see `Compatibility` depends on two things; MIMA-detected changes, and dependencies:

https://github.com/scalacenter/sbt-version-policy/blob/51f9e7c4a04478e24444632f948559df853be40e/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala#L242-L247

It looks like both of those need to be altered in order to support calculating `Compatibility` without `versionPolicyIntention`.