### PR TITLE
Fix `scripted` tests on Mac: use portable `sed -i` syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 .metals
 .vscode
 metals.sbt
+
+# simplest portable 'sed -i' syntax creates backup files, eg 'sed -i.bak' - see https://unix.stackexchange.com/a/92907/46453
+*.bak

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-ci-release/test
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-ci-release/test
@@ -5,7 +5,7 @@ $ exec git config user.name "name"
 
 # Before first release, set `versionPolicyIntention` to `Compatibility.None` because
 # there is no previous release to compare to.
-$ exec sed -i 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.None/' build.sbt
+$ exec sed -i.bak 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.None/' build.sbt
 
 $ exec git add .
 $ exec git commit -m "Initial commit"
@@ -18,7 +18,7 @@ $ exec git tag v1.0.0
 > ci-release
 
 # Reset compatibility intention after release
-$ exec sed -i 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.BinaryAndSourceCompatible/' build.sbt
+$ exec sed -i.bak 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.BinaryAndSourceCompatible/' build.sbt
 
 # New contributions
 $ exec git commit -a -m "Some hard work"

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-dynver/test
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-dynver/test
@@ -13,7 +13,7 @@ $ exec git tag v1.0.0
 > publishLocal
 
 # Reset compatibility intention after release
-$ exec sed -i 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.BinaryAndSourceCompatible/' build.sbt
+$ exec sed -i.bak 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.BinaryAndSourceCompatible/' build.sbt
 
 # New contributions
 $ exec git commit -a -m "Some hard work"


### PR DESCRIPTION
On Mac OS (which is BSD-based), the following sbt `scripted` tests would fail:

* sbt-version-policy/example-sbt-ci-release
* sbt-version-policy/example-sbt-dynver

...with an error message like this:

```
sed: 1: "build.sbt": undefined label 'uild.sbt'
sbt.internal.scripted.TestException: {line 8}  Command failed
```

The failing test line would be like [this](https://github.com/scalacenter/sbt-version-policy/blob/b7fc360d8b55a78e018a45d970a959ffee4d357b/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-ci-release/test#L8C1-L8C103):

```
$ exec sed -i 's/versionPolicyIntention := .*/versionPolicyIntention := Compatibility.None/' build.sbt
```

Unfortunately there's variation between the ways the 'optional' backup-file-extension argument for `sed`'s change-in-place flag (`-i`) is handled on Linux (GNU) vs Mac (BSD). GNU `sed` allows you to completely omit the backup-file-extension argument, as in the `sed` line above - so GitHub CI, running with Linux, passes fine!

However, with BSD `sed`, you have to provide _some_ argument to the `-i` flag, even if it's just `''` to indicate you want no backup at all. Consequently, on Mac the above line was interpreted as specifying a backup-file-extension of `s/versionPolicyIntention .../` (obviously very wrong), and the parser then treated `build.sbt` as the transformation program for `sed` - starting with `b`, which is `sed`'s 'branching' command, and then `uild.sbt` as the label to branch to, thus giving the `undefined label` error - it's a mess.

### Fix

The simplest way to get a portable `sed` command that works on both Mac OS and Linux is to just supply a backup-file-extension argument (eg `.bak`), and then gitignore the resulting `build.sbt.bak` files.

https://www.thegeekstuff.com/2009/12/unix-sed-tutorial-6-examples-for-sed-branching-operation/ https://unix.stackexchange.com/a/92907/46453
https://stackoverflow.com/a/22084103/438886

With this change, the `sbt scripted` suite passes on Mac OS.