### PR TITLE
Fix false "missing dependency" errors for Runtime-only deps

### DIFF
--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/internal/DependencyCheck.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/internal/DependencyCheck.scala
@@ -57,6 +57,7 @@ object DependencyCheck {
       .withName(CrossVersion(previousModuleId.crossVersion, sv, sbv).fold(previousModuleId.name)(_(previousModuleId.name)))
       .withCrossVersion(CrossVersion.disabled)
       .withExplicitArtifacts(Vector.empty)
+      .withConfigurations(Some("compile->compile"))
 
     val mod = depRes.moduleDescriptor(
       ModuleID("dummy-org", "dummy-name", "1.0"),

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/build.sbt
@@ -1,0 +1,22 @@
+ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / organization := "ch.epfl.scala"
+
+// Baseline version with a Runtime-only dependency that has transitive deps
+// not on the Compile classpath (e.g. okhttp, okio, kotlin-stdlib).
+val a = project
+  .settings(
+    name := "runtime-dependency-test",
+    version := "1.0.0",
+    libraryDependencies += "com.squareup.okhttp3" % "okhttp" % "4.12.0" % Runtime,
+  )
+
+// New version with the same Runtime-only dependency.
+// versionPolicyReportDependencyIssues should succeed because the dependency
+// has not changed
+val b = project
+  .settings(
+    name := "runtime-dependency-test",
+    version := "1.1.0",
+    versionPolicyIntention := Compatibility.BinaryCompatible,
+    libraryDependencies += "com.squareup.okhttp3" % "okhttp" % "4.12.0" % Runtime,
+  )

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/project/plugins.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % sys.props("plugin.version"))

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/test
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/test
@@ -1,0 +1,5 @@
+# Publish the baseline version (has okhttp % Runtime)
+> a/publishLocal
+> reload
+# Should succeed: the Runtime dependency has not changed
+> b/versionPolicyReportDependencyIssues


### PR DESCRIPTION
When comparing dependencies between the previous and current version, the plugin creates a dummy module that depends on the previous release artifact. This dependency had no explicit Ivy configuration mapping, which caused the resolved Compile configuration to include the previous artifact's runtime-scoped transitive dependencies.

Meanwhile, the current project's dependencies are extracted from sbt's own update report, which properly isolates Runtime-scoped deps. This asymmetry caused any Runtime-only transitive dependency to appear in the "previous" set but not the "current" set, and get flagged as "missing".

Add an explicit `compile->compile` configuration mapping to the dependency on the previous artifact, ensuring only compile-scoped transitive deps are included — matching what the current side reports.

Fixes #208.