### PR TITLE
use newer Scala versions in scripted tests

### DIFF
--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/api-url/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/api-url/build.sbt
@@ -15,7 +15,7 @@ lazy val a = project
   )
 
 inThisBuild(List(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.12.21",
   organization := "io.github.alexarchambault.sbtversionpolicy.test",
 ))
 

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/assess-compatibility-level/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/assess-compatibility-level/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.7"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / versionScheme := Some("semver-spec")
 
 // https://github.com/sbt/sbt/issues/8248

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/defaults/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/defaults/build.sbt
@@ -47,7 +47,7 @@ lazy val bumpScalaAndAddRule = project
   )
 
 inThisBuild(List(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.12.21",
   organization := "io.github.alexarchambault.sbtversionpolicy.test",
 ))
 

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/dependency-schemes/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/dependency-schemes/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / organization := "ch.epfl.scala"
 
 // https://github.com/sbt/sbt/issues/8248

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/dependency-source-incompatibilities/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/dependency-source-incompatibilities/build.sbt
@@ -131,7 +131,7 @@ lazy val l = project
   )
 
 inThisBuild(List(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.12.21",
   libraryDependencySchemes += "org.typelevel" %% "cats-kernel" % "semver-spec",
   organization := "io.github.alexarchambault.sbtversionpolicy.test",
 ))

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-dynver/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/example-sbt-dynver/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / organization := "com.example"
 // Before the first release, set it to `None` because there is no previous release to compare to
 ThisBuild / versionPolicyIntention := Compatibility.None

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/export-compatibility-report/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/export-compatibility-report/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.18"
 
 // https://github.com/sbt/sbt/issues/8248
 SettingKey[String]("outputPath") := thisProject.value.id

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/in-this-build/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/in-this-build/build.sbt
@@ -20,7 +20,7 @@ lazy val b = project
   )
 
 inThisBuild(List(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.12.21",
   organization := "io.github.alexarchambault.sbtversionpolicy.test2",
   versionPolicyIntention := Compatibility.BinaryCompatible,
   libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "early-semver"

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/issue-127/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/issue-127/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / resolvers += Resolver.typesafeIvyRepo("releases")
 ThisBuild / versionPolicyIntention := Compatibility.None
 

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/mima-early-semver/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/mima-early-semver/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.18"
 
 // https://github.com/sbt/sbt/issues/8248
 SettingKey[String]("outputPath") := thisProject.value.id

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/mima-pvp/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/mima-pvp/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / versionScheme := Some("pvp")
 
 // https://github.com/sbt/sbt/issues/8248

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/mima-semver-spec/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/mima-semver-spec/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / versionScheme := Some("semver-spec")
 
 // https://github.com/sbt/sbt/issues/8248

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / organization := "ch.epfl.scala"
 
 // Baseline version with a Runtime-only dependency that has transitive deps

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/simple/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/simple/build.sbt
@@ -121,7 +121,7 @@ lazy val h = project
   )
 
 inThisBuild(List(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.12.21",
   organization := "io.github.alexarchambault.sbtversionpolicy.test",
   versionPolicyIntention := Compatibility.BinaryCompatible
 ))

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/skip-publish/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/skip-publish/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.18"
 
 // https://github.com/sbt/sbt/issues/8248
 SettingKey[String]("outputPath") := thisProject.value.id

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/version-intention-consistency/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/version-intention-consistency/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / scalaVersion := "2.13.18"
 
 // https://github.com/sbt/sbt/issues/8248
 SettingKey[String]("outputPath") := thisProject.value.id


### PR DESCRIPTION
I'm hoping this will fix the `scripted` failures we're seeing in CI runs such as https://github.com/scalacenter/sbt-version-policy/actions/runs/26847012901