### PR TITLE
Target sbt 2.0.0 final, MiMa -> 1.1.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,8 @@ lazy val `sbt-version-policy` = project
   .settings(
     scriptedLaunchOpts += "-Dplugin.version=" + version.value,
     scriptedBufferLog := false,
-    addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5"),
-    crossScalaVersions += "3.8.3",
+    addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6"),
+    crossScalaVersions += "3.8.4",
     scalacOptions ++= {
       scalaBinaryVersion.value match {
         case "3" =>
@@ -46,7 +46,7 @@ lazy val `sbt-version-policy` = project
         case "2.12" =>
           sbtVersion.value
         case _ =>
-          "2.0.0-RC13"
+          "2.0.0"
       }
     },
     libraryDependencies ++= {

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/runtime-dependency/build.sbt
@@ -1,6 +1,9 @@
 ThisBuild / scalaVersion := "2.13.6"
 ThisBuild / organization := "ch.epfl.scala"
 
+// https://github.com/sbt/sbt/issues/8248
+SettingKey[String]("outputPath") := thisProject.value.id
+
 // Baseline version with a Runtime-only dependency that has transitive deps
 // not on the Compile classpath (e.g. okhttp, okio, kotlin-stdlib).
 val a = project


### PR DESCRIPTION
Follows up on #263 (sbt 2 cross-build) and #269. The cross-build was set up against `2.0.0-RC13`; this targets the released **sbt 2.0.0** so the `_sbt2_3` artifact can be published.

## Changes

- **Target sbt 2.0.0 final** — sbt-2 axis `2.0.0-RC13` → `2.0.0`, Scala `3.8.3` → `3.8.4` (the version sbt 2.0.0 ships with), and `sbt-mima-plugin` `1.1.5` → `1.1.6`.
- **Fix the `runtime-dependency` scripted test under sbt 2** — #263 added `SettingKey[String]("outputPath") := thisProject.value.id` (sbt/sbt#8248) to the multi-version scripted tests so projects sharing a `name` don't collide on sbt 2's `target/out/jvm/<scala>/<name>` layout. `runtime-dependency` was added in #264 (after #263) and missed it, so its `a`/`b` projects (both named `runtime-dependency-test`) failed to load under sbt 2 with "Overlapping output directories".

## Verification

`+test` and `+scripted` pass on both axes (Scala 2.12.21 / sbt 1.x and Scala 3.8.4 / sbt 2.0.0) on JDK 17 — 48/48 scripted tests green.
